### PR TITLE
Release version 1.2.5 with log4j 2.16.0 to fixed CVE-2021-44228.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>tw.fondus.commons</groupId>
 	<artifactId>commons-netcdf</artifactId>
-	<version>1.2.4</version>
+	<version>1.2.5</version>
 	<packaging>jar</packaging>
 
 	<name>The Commons-NetCDF Library</name>
@@ -38,7 +38,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<slf4j.version>1.7.32</slf4j.version>
-		<log4j.version>2.15.0</log4j.version>
+		<log4j.version>2.16.0</log4j.version>
 		<jodatime.version>2.10.13</jodatime.version>
 		<netcdf.version>4.6.16</netcdf.version>
 		<guava.version>31.0.1-jre</guava.version>


### PR DESCRIPTION
Signed-off-by: Bread God <Vipcube@users.noreply.github.com>